### PR TITLE
Instead of producing stubs, modify the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The main scenario for using the tool is to help you with annotating a big and ol
 Features:
 
 + 100% automated, get a bunch of type annotations with no effort.
-+ Unix-way, does only one job and does it well.
++ 100% static, all types are inferred without running the code.
 + A lot of heuristics and smart inference.
 + Actively uses [typeshed](https://github.com/python/typeshed) to find annotations for unannotated dependencies.
 
@@ -32,28 +32,20 @@ class Database:
 ## Installation
 
 ```bash
-python3 -m pip install infer-types retype
+python3 -m pip install infer-types
 ```
 
-This will also install retype which we're going to use to apply generated type annotations back to the code (see Usage below).
-
 ## Usage
-
-First of all, run the tool:
 
 ```bash
 python3 -m infer_types ./example/
 ```
 
-It will infer types for all code in the `example` directory and save [stub files](https://mypy.readthedocs.io/en/stable/stubs.html) inside of `types` directory.
-
-The next thing you need to do is to apply the stub files back to the code. For that, we're going to use [retype](https://github.com/ambv/retype):
+The infer-types tool uses the new fancy syntax for type annotations introduced in Python 3.10. So, instead of `Optional[str]` it will emit `str | None`. If your code is supposed to run on an older version of Python, add `from __future__ import annotations` at the beginning of each file. It will solve the issue and also make startup of your app faster. You can do that using [isort](https://github.com/PyCQA/isort):
 
 ```bash
-retype -it ./example/ ./example/
+isort --add-import 'from __future__ import annotations' ./example/
 ```
-
-The infer-types tool uses the new fancy syntax for type annotations introduced in Python 3.10. So, instead of `Optional[str]` it will emit `str | None`. If your code is supposed to run on an older version of Python, add `from __future__ import annotations` at the beginning of each file. It will solve the issue and also make startup of your app faster.
 
 See [awesome-python-typing](https://github.com/typeddjango/awesome-python-typing) for more tools to help you with annotating your code.
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,16 @@ python3 -m pip install infer-types
 python3 -m infer_types ./example/
 ```
 
-The infer-types tool uses the new fancy syntax for type annotations introduced in Python 3.10. So, instead of `Optional[str]` it will emit `str | None`. If your code is supposed to run on an older version of Python, add `from __future__ import annotations` at the beginning of each file. It will solve the issue and also make startup of your app faster. You can do that using [isort](https://github.com/PyCQA/isort):
+The tool will add new import statements that can be duplicated and are located not at the top of the file. To fix it, run [isort](https://github.com/PyCQA/isort):
 
 ```bash
-isort --add-import 'from __future__ import annotations' ./example/
+python3 -m isort ./example/
+```
+
+The infer-types tool uses the new fancy syntax for type annotations introduced in Python 3.10. So, instead of `Optional[str]` it will emit `str | None`. If your code is supposed to run on an older version of Python, add `from __future__ import annotations` at the beginning of each file. It will solve the issue and also make startup of your app faster. You can also do that with isort:
+
+```bash
+python3 -m isort --add-import 'from __future__ import annotations' ./example/
 ```
 
 See [awesome-python-typing](https://github.com/typeddjango/awesome-python-typing) for more tools to help you with annotating your code.

--- a/infer_types/__init__.py
+++ b/infer_types/__init__.py
@@ -3,4 +3,4 @@
 from ._cli import entrypoint, main
 
 __all__ = ['entrypoint', 'main']
-__version__ = '0.2.0'
+__version__ = '0.3.0'

--- a/infer_types/_cli.py
+++ b/infer_types/_cli.py
@@ -25,13 +25,13 @@ class Config:
     stream: TextIO
 
 
-def generate_stubs(root: Path, config: Config) -> None:
+def add_annotations(root: Path, config: Config) -> None:
     inferno = Inferno()
     for path in root.iterdir():
         if path.is_dir():
             if config.skip_migrations and path.name == 'migrations':
                 continue
-            generate_stubs(path, config)
+            add_annotations(path, config)
             continue
         if path.suffix != '.py':
             continue
@@ -85,7 +85,7 @@ def main(argv: list[str], stream: TextIO) -> int:
         stream=stream,
     )
     try:
-        generate_stubs(args.dir, config)
+        add_annotations(args.dir, config)
     except Exception:  # pragma: no cover
         pdb.post_mortem()
     return 0

--- a/infer_types/_cli.py
+++ b/infer_types/_cli.py
@@ -13,6 +13,9 @@ from ._inferno import Inferno
 @dataclass(frozen=True)
 class Config:
     format: bool
+    skip_tests: bool
+    skip_migrations: bool
+    dry: bool
     stream: TextIO
 
 
@@ -20,14 +23,19 @@ def generate_stubs(root: Path, config: Config) -> None:
     inferno = Inferno()
     for path in root.iterdir():
         if path.is_dir():
+            if config.skip_migrations and path.name == 'migrations':
+                continue
             generate_stubs(path, config)
             continue
         if path.suffix != '.py':
             continue
+        if config.skip_tests and path.name.startswith('test_'):
+            continue
         new_source = inferno.transform(path)
         if config.format:
             new_source = format_code(new_source)
-        path.write_text(new_source)
+        if not config.dry:
+            path.write_text(new_source)
         print(path, file=config.stream)
 
 
@@ -41,8 +49,26 @@ def main(argv: list[str], stream: TextIO) -> int:
         '--format', action='store_true',
         help='run available code formatters on the modified files',
     )
+    parser.add_argument(
+        '--skip-tests', action='store_true',
+        help='skip test files (starting with `test_`)',
+    )
+    parser.add_argument(
+        '--skip-migrations', action='store_true',
+        help='skip Django migration files',
+    )
+    parser.add_argument(
+        '--dry', action='store_true',
+        help='do not modify any files',
+    )
     args = parser.parse_args(argv)
-    config = Config(format=args.format, stream=stream)
+    config = Config(
+        format=args.format,
+        skip_tests=args.skip_tests,
+        skip_migrations=args.skip_migrations,
+        dry=args.dry,
+        stream=stream,
+    )
     generate_stubs(args.dir, config)
     return 0
 

--- a/infer_types/_extractors.py
+++ b/infer_types/_extractors.py
@@ -78,7 +78,7 @@ def _extract_inherit_method(func_node: astroid.FunctionDef) -> Type:
         if not isinstance(parent, astroid.FunctionDef):
             continue
         qname: str = parent.qname()
-        mod_name, cls_name, func_name = qname.split('.')
+        mod_name, cls_name, func_name = qname.rsplit('.', maxsplit=2)
         assert func_name == func_node.name
 
         # extract type from the return type annotation

--- a/infer_types/_fsig.py
+++ b/infer_types/_fsig.py
@@ -11,10 +11,9 @@ class FSig:
     return_type: Type
 
     @property
-    def imports(self) -> set[str]:
+    def imports(self) -> frozenset[str]:
         return self.return_type.imports
 
     @property
-    def stub(self) -> str:
-        rtype = self.return_type.annotation
-        return f'def {self.name}({self.args}) -> {rtype}: ...'
+    def annotation(self) -> str:
+        return self.return_type.annotation

--- a/infer_types/_inferno.py
+++ b/infer_types/_inferno.py
@@ -7,7 +7,7 @@ from typing import Iterator
 import astroid
 from ._fsig import FSig
 from ._extractors import get_return_type
-from ._transformer import Transformer, InsertReturnType
+from ._transformer import Transformer, InsertReturnType, InsertImport, Transformation
 
 
 @dataclass
@@ -23,12 +23,13 @@ class Inferno:
 
     def _get_transforms_for_node(
         self, node: astroid.NodeNG,
-    ) -> Iterator[InsertReturnType]:
+    ) -> Iterator[Transformation]:
         # infer return type for function
         if isinstance(node, astroid.FunctionDef):
             sig = self._infer_sig(node)
             if sig is not None:
-                # yield from sig.imports
+                for import_stmt in sig.imports:
+                    yield InsertImport(node, import_stmt)
                 yield InsertReturnType(node, sig.annotation)
             return
 

--- a/infer_types/_inferno.py
+++ b/infer_types/_inferno.py
@@ -23,7 +23,7 @@ class Inferno:
     def _get_stubs_for_node(self, node: astroid.NodeNG) -> Iterator[str]:
         # infer return type for function
         if isinstance(node, astroid.FunctionDef):
-            sig = self.infer_sig(node)
+            sig = self._infer_sig(node)
             if sig is not None:
                 yield from sig.imports
                 yield sig.stub
@@ -36,7 +36,7 @@ class Inferno:
             for subnode in node.body:
                 if not isinstance(subnode, astroid.FunctionDef):
                     continue
-                sig = self.infer_sig(subnode)
+                sig = self._infer_sig(subnode)
                 if sig is None:
                     continue
                 dec_qname: str
@@ -53,7 +53,7 @@ class Inferno:
             yield f'class {node.name}:'
             yield from sigs
 
-    def infer_sig(self, node: astroid.FunctionDef) -> FSig | None:
+    def _infer_sig(self, node: astroid.FunctionDef) -> FSig | None:
         if node.returns is not None:
             return None
         return_type = get_return_type(node)

--- a/infer_types/_inferno.py
+++ b/infer_types/_inferno.py
@@ -7,31 +7,32 @@ from typing import Iterator
 import astroid
 from ._fsig import FSig
 from ._extractors import get_return_type
+from ._transformer import Transformer, InsertReturnType
 
 
 @dataclass
 class Inferno:
-    def generate_stub(self, path: Path) -> str:
+    def transform(self, path: Path) -> str:
         source = path.read_text()
+        tr = Transformer(source)
         root = astroid.parse(source, path=str(path))
-
-        result: list[str] = []
         for node in root.body:
-            result.extend(self._get_stubs_for_node(node))
-        return '\n'.join(result) + '\n'
+            for transform in self._get_transforms_for_node(node):
+                tr.add(transform)
+        return tr.apply()
 
-    def _get_stubs_for_node(self, node: astroid.NodeNG) -> Iterator[str]:
+    def _get_transforms_for_node(
+        self, node: astroid.NodeNG,
+    ) -> Iterator[InsertReturnType]:
         # infer return type for function
         if isinstance(node, astroid.FunctionDef):
             sig = self._infer_sig(node)
             if sig is not None:
-                yield from sig.imports
-                yield sig.stub
+                # yield from sig.imports
+                yield InsertReturnType(node, sig.annotation)
             return
 
         # infer return type for all methods of a class
-        imports: set[str] = set()
-        sigs: list[str] = []
         if isinstance(node, astroid.ClassDef):
             for subnode in node.body:
                 if not isinstance(subnode, astroid.FunctionDef):
@@ -39,19 +40,15 @@ class Inferno:
                 sig = self._infer_sig(subnode)
                 if sig is None:
                     continue
-                dec_qname: str
-                for dec_qname in subnode.decoratornames():
-                    mod_name, _, dec_name = dec_qname.rpartition('.')
-                    if mod_name != 'builtins':
-                        imports.add(f'from {mod_name} import {dec_name}')
-                    if mod_name:
-                        sigs.append(f'    @{dec_name}')
-                imports.update(sig.imports)
-                sigs.append(f'    {sig.stub}')
-        yield from imports
-        if sigs:
-            yield f'class {node.name}:'
-            yield from sigs
+                # dec_qname: str
+                # for dec_qname in subnode.decoratornames():
+                #     mod_name, _, dec_name = dec_qname.rpartition('.')
+                #     if mod_name != 'builtins':
+                #         imports.add(f'from {mod_name} import {dec_name}')
+                #     if mod_name:
+                #         sigs.append(f'    @{dec_name}')
+                # imports.update(sig.imports)
+                yield InsertReturnType(node, sig.annotation)
 
     def _infer_sig(self, node: astroid.FunctionDef) -> FSig | None:
         if node.returns is not None:

--- a/infer_types/_inferno.py
+++ b/infer_types/_inferno.py
@@ -48,7 +48,7 @@ class Inferno:
                 #     if mod_name:
                 #         sigs.append(f'    @{dec_name}')
                 # imports.update(sig.imports)
-                yield InsertReturnType(node, sig.annotation)
+                yield InsertReturnType(subnode, sig.annotation)
 
     def _infer_sig(self, node: astroid.FunctionDef) -> FSig | None:
         if node.returns is not None:

--- a/infer_types/_inferno.py
+++ b/infer_types/_inferno.py
@@ -41,14 +41,8 @@ class Inferno:
                 sig = self._infer_sig(subnode)
                 if sig is None:
                     continue
-                # dec_qname: str
-                # for dec_qname in subnode.decoratornames():
-                #     mod_name, _, dec_name = dec_qname.rpartition('.')
-                #     if mod_name != 'builtins':
-                #         imports.add(f'from {mod_name} import {dec_name}')
-                #     if mod_name:
-                #         sigs.append(f'    @{dec_name}')
-                # imports.update(sig.imports)
+                for import_stmt in sig.imports:
+                    yield InsertImport(node, import_stmt)
                 yield InsertReturnType(subnode, sig.annotation)
 
     def _infer_sig(self, node: astroid.FunctionDef) -> FSig | None:

--- a/infer_types/_transformer.py
+++ b/infer_types/_transformer.py
@@ -27,7 +27,7 @@ class InsertImport(Transformation):
 
     Currently, inserts it right after the function. Let isort fix it.
     """
-    node: astroid.FunctionDef
+    node: astroid.FunctionDef | astroid.ClassDef
     text: str
 
     def pick_position(self, tr: Transformer) -> tuple[int, int]:

--- a/infer_types/_transformer.py
+++ b/infer_types/_transformer.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from functools import cached_property
+from pathlib import Path
+import tokenize
+
+
+@dataclass(frozen=True)
+class InsertReturnType:
+    """Insert the return type annotation into the function at the given line.
+    """
+    line: int
+    text: str
+
+    def pick_position(self, tr: Transformer) -> tuple[int, int]:
+        assert tr.colons, 'no colons found'
+        for line, col in tr.colons:
+            if line >= self.line:
+                return (line, col)
+        msg = f'cannot find colon matching the function at {self.line}'
+        raise LookupError(msg)
+
+    def as_str(self) -> str:
+        return f' -> {self.text}'
+
+
+@dataclass(frozen=True)
+class Transformer:
+    """Insert snippets of text into the source code.
+    """
+    path: Path
+    _transforms: list[InsertReturnType] = field(default_factory=list)
+
+    def add(self, transform: InsertReturnType) -> None:
+        """Add new transformation to pending.
+        """
+        self._transforms.append(transform)
+
+    def apply(self) -> None:
+        """Apply all pending transformations in place.
+        """
+        old_text = self.path.read_text(encoding='utf8')
+        new_text = self._transform(old_text)
+        self.path.write_text(new_text, encoding='utf8')
+
+    def _transform(self, text: str) -> str:
+        self._transforms.sort(key=lambda t: t.line, reverse=True)
+        lines = text.splitlines(keepends=True)
+        for transform in self._transforms:
+            lineno, col = transform.pick_position(self)
+            lineno -= 1
+            line = lines[lineno]
+            lines[lineno] = line[:col] + transform.as_str() + line[col:]
+        return ''.join(lines)
+
+    @cached_property
+    def colons(self) -> tuple[tuple[int, int], ...]:
+        """Positions of all colons.
+        """
+        result = []
+        for token in self._tokens:
+            if token.type == tokenize.OP and token.string == ':':
+                result.append(token.start)
+        return tuple(result)
+
+    @cached_property
+    def _tokens(self) -> tuple[tokenize.TokenInfo, ...]:
+        with self.path.open('rb') as stream:
+            return tuple(tokenize.tokenize(stream.__next__))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ Source = "https://github.com/orsinium-labs/infer-types"
 
 [tool.mypy]
 files = ["infer_types"]
-python_version = 3.7
+python_version = 3.8
 ignore_missing_imports = true
 # follow_imports = "silent"
 show_error_codes = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ addopts = [
 exclude_lines = [
     "pragma: no cover",
     "if TYPE_CHECKING",
+    "raise NotImplementedError",
     "    pass",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ addopts = [
     "--cov=infer_types",
     "--cov-report=html",
     "--cov-report=term-missing:skip-covered",
-    "--cov-fail-under=88",
+    "--cov-fail-under=91",
 ]
 
 [tool.coverage.report]
@@ -67,6 +67,7 @@ exclude_lines = [
     "pragma: no cover",
     "if TYPE_CHECKING",
     "raise NotImplementedError",
+    "except ImportError:",
     "    pass",
 ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[flake8]
+max-line-length = 90
+ignore =
+exclude =
+    .venvs/

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,3 +33,93 @@ def test_main(tmp_path: Path):
 
     # check modifications
     assert source_file.read_text() == dedent(EXPECTED)
+
+
+def test_recursive_file_lookup(tmp_path: Path):
+    # prepare files and dirs
+    source_dir1 = tmp_path / 'source'
+    source_dir1.mkdir()
+    source_dir2 = source_dir1 / 'subdir'
+    source_dir2.mkdir()
+    source_file1 = source_dir1 / 'example1.py'
+    source_file2 = source_dir2 / 'example2.py'
+    source_file1.write_text(dedent(GIVEN))
+    source_file2.write_text(dedent(GIVEN))
+
+    # call the CLI
+    stream = StringIO()
+    code = main([str(tmp_path)], stream)
+    assert code == 0
+
+    # check modifications
+    assert source_file1.read_text() == dedent(EXPECTED)
+    assert source_file2.read_text() == dedent(EXPECTED)
+
+
+def test_skip_migrations(tmp_path: Path):
+    # prepare files and dirs
+    source_dir = tmp_path / 'source'
+    source_dir.mkdir()
+    migrations_dir = source_dir / 'migrations'
+    migrations_dir.mkdir()
+    source_file = source_dir / 'example1.py'
+    migration_file = migrations_dir / 'example2.py'
+    source_file.write_text(dedent(GIVEN))
+    migration_file.write_text(dedent(GIVEN))
+
+    # call the CLI
+    stream = StringIO()
+    code = main([str(tmp_path), '--skip-migrations'], stream)
+    assert code == 0
+
+    # check modifications
+    assert source_file.read_text() == dedent(EXPECTED)
+    assert migration_file.read_text() == dedent(GIVEN)
+
+
+def test_skip_tests(tmp_path: Path):
+    # prepare files and dirs
+    source_dir = tmp_path / 'source'
+    source_dir.mkdir()
+    source_file = source_dir / 'example.py'
+    test_file = source_dir / 'test_example.py'
+    source_file.write_text(dedent(GIVEN))
+    test_file.write_text(dedent(GIVEN))
+
+    # call the CLI
+    stream = StringIO()
+    code = main([str(tmp_path), '--skip-tests'], stream)
+    assert code == 0
+
+    # check modifications
+    assert source_file.read_text() == dedent(EXPECTED)
+    assert test_file.read_text() == dedent(GIVEN)
+
+
+def test_skip_non_python(tmp_path: Path):
+    # prepare files and dirs
+    source_dir = tmp_path / 'source'
+    source_dir.mkdir()
+    source_file = source_dir / 'example.py'
+    ruby_file = source_dir / 'example.rb'
+    source_file.write_text(dedent(GIVEN))
+    ruby_file.write_text(dedent(GIVEN))
+
+    # call the CLI
+    stream = StringIO()
+    code = main([str(tmp_path)], stream)
+    assert code == 0
+
+    # check modifications
+    assert source_file.read_text() == dedent(EXPECTED)
+    assert ruby_file.read_text() == dedent(GIVEN)
+
+
+def test_format_doesnt_explode(tmp_path: Path):
+    # prepare files and dirs
+    source_file = tmp_path / 'example.py'
+    source_file.write_text(dedent(GIVEN))
+    # call the CLI
+    stream = StringIO()
+    code = main([str(tmp_path), '--format'], stream)
+    assert code == 0

--- a/tests/test_inferno.py
+++ b/tests/test_inferno.py
@@ -151,6 +151,7 @@ def transform(tmp_path: Path) -> Callable:
     def f():
         yield x
     ---
+    from typing import Iterator
     def f() -> Iterator:
         yield x
     """,

--- a/tests/test_inferno.py
+++ b/tests/test_inferno.py
@@ -7,69 +7,157 @@ from infer_types._inferno import Inferno
 
 
 @pytest.fixture
-def get_stubs(tmp_path: Path) -> Callable:
+def transform(tmp_path: Path) -> Callable:
     def callback(source: str) -> str:
         inferno = Inferno()
         path = tmp_path / 'example.py'
         source = dedent(source)
         path.write_text(source)
-        result = inferno.generate_stub(path).strip()
-        return '\n'.join(line for line in result.splitlines() if line)
+        return inferno.transform(path)
     return callback
 
 
-def test_inferno_expr(get_stubs):
-    result = get_stubs("""
-        def f(x):
-            return len(x)
-    """)
-    assert result == 'def f(x) -> int: ...'
-
-
-def test_infer_bare_return(get_stubs):
-    result = get_stubs("""
-        def f(x):
-            if x == y:
-                return
+@pytest.mark.parametrize('fused', [
+    # basic inference
+    """
+    def f(x):
+        return len(x)
+    ---
+    def f(x) -> int:
+        return len(x)
+    """,
+    # bare return has type None
+    """
+    def f(x):
+        if x == y:
+            return
+        return 13
+    ---
+    def f(x) -> int | None:
+        if x == y:
+            return
+        return 13
+    """,
+    # nested functions must be ignored
+    """
+    def f(x):
+        def f2():
+            return 'hello'
+        return 13
+    ---
+    def f(x) -> int:
+        def f2():
+            return 'hello'
+        return 13
+    """,
+    # multiple returns with the same type
+    """
+    def f(x):
+        if x == y:
+            return 12
+        return 13
+    ---
+    def f(x) -> int:
+        if x == y:
+            return 12
+        return 13
+    """,
+    # cannot infer, do not modify
+    """
+    def f(x):
+        return min(x)
+    ---
+    def f(x):
+        return min(x)
+    """,
+    # skip already annotated
+    """
+    def f() -> int:
+        return "hi"
+    ---
+    def f() -> int:
+        return "hi"
+    """,
+    # infer class methods
+    """
+    SOMETHING = 13
+    class C:
+        some_attr: str = 14
+        def m(self, x):
             return 13
-    """)
-    assert result == 'def f(x) -> int | None: ...'
-
-
-def test_skip_subfuncs(get_stubs):
-    result = get_stubs("""
-        def f(x):
-            def f2():
-                return 'hello'
+    ---
+    SOMETHING = 13
+    class C:
+        some_attr: str = 14
+        def m(self, x) -> int:
             return 13
-    """)
-    assert result == 'def f(x) -> int: ...'
-
-
-def test_simplify_union_same_type(get_stubs):
-    result = get_stubs("""
-        def f(x):
-            if x == y:
-                return 12
+    """,
+    # cannot infer some class methods
+    """
+    class C:
+        def m(self, x):
+            return x
+    ---
+    class C:
+        def m(self, x):
+            return x
+    """,
+    # can infer only one return statement, roll with it
+    """
+    def f(x):
+        if x == y:
+            return x
+        else:
             return 13
-    """)
-    assert result == 'def f(x) -> int: ...'
-
-
-def test_cannot_infer_expr(get_stubs):
-    result = get_stubs("""
-        def f(x):
-            return min(x)
-    """)
-    assert result == ''
-
-
-def test_skip_annotated(get_stubs):
-    result = get_stubs("""
-        def f() -> int:
-            return "hi"
-    """)
-    assert result == ''
+    ---
+    def f(x) -> int:
+        if x == y:
+            return x
+        else:
+            return 13
+    """,
+    # bare return
+    """
+    def f(x):
+        if x:
+            return
+        do_something()
+    ---
+    def f(x) -> None:
+        if x:
+            return
+        do_something()
+    """,
+    # no return
+    """
+    def f(x):
+        do_something()
+    ---
+    def f(x) -> None:
+        do_something()
+    """,
+    # magic method
+    """
+    class A:
+        def __str__(self):
+            return x
+    ---
+    class A:
+        def __str__(self) -> str:
+            return x
+    """,
+    # yield
+    """
+    def f():
+        yield x
+    ---
+    def f() -> Iterator:
+        yield x
+    """,
+])
+def test_inferno(transform, fused: str) -> None:
+    given, expected = fused.split('---')
+    assert transform(given) == dedent(expected)
 
 
 @pytest.mark.parametrize('expr', [
@@ -85,166 +173,91 @@ def test_skip_annotated(get_stubs):
     'x: int | None',
     'x: int | None = 13',
 ])
-def test_preserve_args(get_stubs, expr):
-    result = get_stubs(f"""
+def test_preserve_args(transform, expr):
+    given = f"""
         def f({expr}):
             return 1
-    """)
-    assert result == f'def f({expr}) -> int: ...'
+    """
+    expected = f"""
+        def f({expr}) -> int:
+            return 1
+    """
+    assert transform(given) == dedent(expected)
 
 
-def test_infer_class_methods(get_stubs):
-    actual = get_stubs("""
-        SOMETHING = 13
-        class C:
-            some_attr: str = 14
-            def m(self, x):
-                return 13
-    """)
-    expected = dedent("""
-        class C:
-            def m(self, x) -> int: ...
-    """)
-    lactual = [line for line in actual.splitlines() if line]
-    lexpected = [line for line in expected.splitlines() if line]
-    assert lactual == lexpected
+# def test_preserve_property_decorator(transform):
+#     actual = transform("""
+#         class C:
+#             @property
+#             @garbage
+#             def m(self, x):
+#                 return 13
+#     """)
+#     expected = dedent("""
+#         class C:
+#             @property
+#             def m(self, x) -> int: ...
+#     """)
+#     lactual = [line for line in actual.splitlines() if line]
+#     lexpected = [line for line in expected.splitlines() if line]
+#     assert lactual == lexpected
 
 
-def test_preserve_property_decorator(get_stubs):
-    actual = get_stubs("""
-        class C:
-            @property
-            @garbage
-            def m(self, x):
-                return 13
-    """)
-    expected = dedent("""
-        class C:
-            @property
-            def m(self, x) -> int: ...
-    """)
-    lactual = [line for line in actual.splitlines() if line]
-    lexpected = [line for line in expected.splitlines() if line]
-    assert lactual == lexpected
+# def test_preserve_cached_property_decorator(transform):
+#     actual = transform("""
+#         from functools import cached_property
+#         class C:
+#             @cached_property
+#             def m(self, x):
+#                 return 13
+#     """)
+#     expected = dedent("""
+#         from functools import cached_property
+#         class C:
+#             @cached_property
+#             def m(self, x) -> int: ...
+#     """)
+#     lactual = [line for line in actual.splitlines() if line]
+#     lexpected = [line for line in expected.splitlines() if line]
+#     assert lactual == lexpected
 
 
-def test_preserve_cached_property_decorator(get_stubs):
-    actual = get_stubs("""
-        from functools import cached_property
-        class C:
-            @cached_property
-            def m(self, x):
-                return 13
-    """)
-    expected = dedent("""
-        from functools import cached_property
-        class C:
-            @cached_property
-            def m(self, x) -> int: ...
-    """)
-    lactual = [line for line in actual.splitlines() if line]
-    lexpected = [line for line in expected.splitlines() if line]
-    assert lactual == lexpected
+# @pytest.mark.parametrize('g_imp, g_expr, e_imp, e_type', [
+#     (
+#         'import datetime', 'datetime.date(1,2,3)',
+#         'from datetime import date', 'date',
+#     ),
+#     (
+#         'from datetime import date', 'date(1,2,3)',
+#         'from datetime import date', 'date',
+#     ),
+#     (
+#         'import ast', 'ast.walk(x)',
+#         'from typing import Iterator', 'Iterator',
+#     ),
+# ])
+# def test_import_types(transform, g_imp, g_expr, e_imp, e_type):
+#     result = transform(f"""
+#         {g_imp}
+
+#         def f():
+#             return {g_expr}
+#     """)
+#     assert result == f'{e_imp}\ndef f() -> {e_type}: ...'
 
 
-def test_cannot_infer_class_methods(get_stubs):
-    actual = get_stubs("""
-        class C:
-            def m(self, x):
-                return x
-    """)
-    assert actual == ""
+# def test_inherit(transform):
+#     result = transform("""
+#         class A:
+#             def f(self) -> str:
+#                 return x
 
-
-def test_can_infer_only_one(get_stubs):
-    actual = get_stubs("""
-        def f(x):
-            if x == y:
-                return x
-            else:
-                return 13
-    """)
-    expected = dedent("def f(x) -> int: ...")
-    lactual = [line for line in actual.splitlines() if line]
-    lexpected = [line for line in expected.splitlines() if line]
-    assert lactual == lexpected
-
-
-@pytest.mark.parametrize('g_imp, g_expr, e_imp, e_type', [
-    (
-        'import datetime', 'datetime.date(1,2,3)',
-        'from datetime import date', 'date',
-    ),
-    (
-        'from datetime import date', 'date(1,2,3)',
-        'from datetime import date', 'date',
-    ),
-    (
-        'import ast', 'ast.walk(x)',
-        'from typing import Iterator', 'Iterator',
-    ),
-])
-def test_import_types(get_stubs, g_imp, g_expr, e_imp, e_type):
-    result = get_stubs(f"""
-        {g_imp}
-
-        def f():
-            return {g_expr}
-    """)
-    assert result == f'{e_imp}\ndef f() -> {e_type}: ...'
-
-
-def test_detect_bare_return(get_stubs):
-    result = get_stubs("""
-        def f(x):
-            if x:
-                return
-            do_something()
-    """)
-    assert result == 'def f(x) -> None: ...'
-
-
-def test_detect_no_return(get_stubs):
-    result = get_stubs("""
-        def f():
-            do_something()
-    """)
-    assert result == 'def f() -> None: ...'
-
-
-def test_detect_yield(get_stubs):
-    result = get_stubs("""
-        def f():
-            yield x
-    """)
-    assert result == 'from typing import Iterator\ndef f() -> Iterator: ...'
-
-
-def test_detect_magic_method(get_stubs):
-    result = get_stubs("""
-        class A:
-            def __str__(self):
-                return x
-    """)
-    expected = dedent("""
-        class A:
-            def __str__(self) -> str: ...
-    """)
-    assert result.strip() == expected.strip()
-
-
-def test_inherit(get_stubs):
-    result = get_stubs("""
-        class A:
-            def f(self) -> str:
-                return x
-
-        class B(A):
-            def f(self):
-                return y
-    """)
-    expected = dedent("""
-        class B:
-            def f(self) -> str: ...
-    """)
-    assert result.strip() == expected.strip()
+#         class B(A):
+#             def f(self):
+#                 return y
+#     """)
+#     expected = dedent("""
+#         class B:
+#             def f(self) -> str: ...
+#     """)
+#     assert result.strip() == expected.strip()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,14 +8,17 @@ SOURCE = """
         return len(x)
 """
 
+EXPECTED = """
+    def f(x) -> int:
+        return len(x)
+"""
+
 
 def test_main(tmp_path: Path):
-    spath = tmp_path / 'source'
-    spath.mkdir()
-    (spath / 'example.py').write_text(dedent(SOURCE))
-    tpath = tmp_path / 'types'
-    flags = ['--pyi-dir', str(tpath), str(spath)]
-    res = subprocess.run([sys.executable, '-m', 'infer_types', *flags])
+    source_dir = tmp_path / 'source'
+    source_dir.mkdir()
+    source_file = source_dir / 'example.py'
+    source_file.write_text(dedent(SOURCE))
+    res = subprocess.run([sys.executable, '-m', 'infer_types', str(source_dir)])
     assert res.returncode == 0
-    out_path = tpath / 'example.pyi'
-    assert out_path.exists()
+    assert source_file.read_text() == dedent(EXPECTED)

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1,25 +1,17 @@
 from textwrap import dedent
 from infer_types._transformer import Transformer, InsertReturnType
-from pathlib import Path
 import astroid
 
 
-def add_ret_ann(
-    tmp_path: Path,
-    given: str,
-    annotation: str,
-) -> str:
-    file_path = tmp_path / 'example.py'
-    file_path.write_text(dedent(given))
-    tr = Transformer(path=file_path)
+def add_ret_ann(given: str, annotation: str) -> str:
+    tr = Transformer(dedent(given))
     tree = astroid.parse(given)
     patch = InsertReturnType(tree.body[0], annotation)
     tr.add(patch)
-    tr.apply()
-    return file_path.read_text()
+    return tr.apply()
 
 
-def test_simple(tmp_path: Path) -> None:
+def test_simple() -> None:
     given = """
         def f():
             pass
@@ -28,11 +20,11 @@ def test_simple(tmp_path: Path) -> None:
         def f() -> int:
             pass
     """
-    actual = add_ret_ann(tmp_path, given, 'int')
+    actual = add_ret_ann(given, 'int')
     assert actual == dedent(expected)
 
 
-def test_with_args(tmp_path: Path) -> None:
+def test_with_args() -> None:
     given = """
         def f(a: int, b):
             pass
@@ -41,11 +33,11 @@ def test_with_args(tmp_path: Path) -> None:
         def f(a: int, b) -> int:
             pass
     """
-    actual = add_ret_ann(tmp_path, given, 'int')
+    actual = add_ret_ann(given, 'int')
     assert actual == dedent(expected)
 
 
-def test_multiline(tmp_path: Path) -> None:
+def test_multiline() -> None:
     given = """
         def f(
             a: int,
@@ -60,11 +52,11 @@ def test_multiline(tmp_path: Path) -> None:
         ) -> str:
             pass
     """
-    actual = add_ret_ann(tmp_path, given, 'str')
+    actual = add_ret_ann(given, 'str')
     assert actual == dedent(expected)
 
 
-def test_empty_body(tmp_path: Path) -> None:
+def test_empty_body() -> None:
     given = """
         def f(a, b: str):
             '''hello'''
@@ -73,5 +65,5 @@ def test_empty_body(tmp_path: Path) -> None:
         def f(a, b: str) -> int:
             '''hello'''
     """
-    actual = add_ret_ann(tmp_path, given, 'int')
+    actual = add_ret_ann(given, 'int')
     assert actual == dedent(expected)

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1,0 +1,30 @@
+from textwrap import dedent
+from infer_types._transformer import Transformer, InsertReturnType
+from pathlib import Path
+
+
+def transform(
+    tmp_path: Path,
+    given: str,
+    *patches: InsertReturnType,
+) -> str:
+    file_path = tmp_path / 'example.py'
+    file_path.write_text(dedent(given))
+    tr = Transformer(path=file_path)
+    for patch in patches:
+        tr.add(patch)
+    tr.apply()
+    return file_path.read_text()
+
+
+def test_simple(tmp_path: Path) -> None:
+    given = """
+        def f():
+            pass
+    """
+    expected = """
+        def f() -> int:
+            pass
+    """
+    actual = transform(tmp_path, given, InsertReturnType(1, 'int'))
+    assert actual == dedent(expected)

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1,18 +1,20 @@
 from textwrap import dedent
 from infer_types._transformer import Transformer, InsertReturnType
 from pathlib import Path
+import astroid
 
 
-def transform(
+def add_ret_ann(
     tmp_path: Path,
     given: str,
-    *patches: InsertReturnType,
+    annotation: str,
 ) -> str:
     file_path = tmp_path / 'example.py'
     file_path.write_text(dedent(given))
     tr = Transformer(path=file_path)
-    for patch in patches:
-        tr.add(patch)
+    tree = astroid.parse(given)
+    patch = InsertReturnType(tree.body[0], annotation)
+    tr.add(patch)
     tr.apply()
     return file_path.read_text()
 
@@ -26,5 +28,50 @@ def test_simple(tmp_path: Path) -> None:
         def f() -> int:
             pass
     """
-    actual = transform(tmp_path, given, InsertReturnType(1, 'int'))
+    actual = add_ret_ann(tmp_path, given, 'int')
+    assert actual == dedent(expected)
+
+
+def test_with_args(tmp_path: Path) -> None:
+    given = """
+        def f(a: int, b):
+            pass
+    """
+    expected = """
+        def f(a: int, b) -> int:
+            pass
+    """
+    actual = add_ret_ann(tmp_path, given, 'int')
+    assert actual == dedent(expected)
+
+
+def test_multiline(tmp_path: Path) -> None:
+    given = """
+        def f(
+            a: int,
+            b: float,
+        ):
+            pass
+    """
+    expected = """
+        def f(
+            a: int,
+            b: float,
+        ) -> str:
+            pass
+    """
+    actual = add_ret_ann(tmp_path, given, 'str')
+    assert actual == dedent(expected)
+
+
+def test_empty_body(tmp_path: Path) -> None:
+    given = """
+        def f(a, b: str):
+            '''hello'''
+    """
+    expected = """
+        def f(a, b: str) -> int:
+            '''hello'''
+    """
+    actual = add_ret_ann(tmp_path, given, 'int')
     assert actual == dedent(expected)


### PR DESCRIPTION
Issue: The [retype](https://github.com/ambv/retype) tool that I used to apply type annotations produced by infer-types is not maintained anymore and doesn't support the new type annotations syntax.

Solution: instead of producing stubs, modify the code in place. That way, the tool usage is even simpler and we don't depend on third-party tools.

This is a breaking change.