### PR TITLE
Avoid false-positives for methods with no return

### DIFF
--- a/infer_types/_cli.py
+++ b/infer_types/_cli.py
@@ -17,6 +17,9 @@ except ImportError:
     import pdb  # type: ignore[no-redef]
 
 
+TEST_NAMES = frozenset({'tests.py', 'conftest.py'})
+
+
 @dataclass(frozen=True)
 class Config:
     format: bool            # run code formatters
@@ -49,8 +52,13 @@ def add_annotations(root: Path, config: Config) -> None:
             continue
         if path.suffix != '.py':
             continue
-        if config.skip_tests and path.name.startswith('test_'):
-            continue
+        if config.skip_tests:
+            if path.name.startswith('test_'):
+                continue
+            if path.name in TEST_NAMES:
+                continue
+            if 'tests' in path.parts:
+                continue
         new_source = inferno.transform(path)
         if config.format:
             new_source = format_code(new_source)

--- a/tests/test_inferno.py
+++ b/tests/test_inferno.py
@@ -215,6 +215,64 @@ def transform(tmp_path: Path) -> Callable:
         def m(self, x) -> Iterator:
             yield 12
     """,
+    # don't infer no return for empty base class methods
+    """
+    class A:
+        def m(self, x):
+            raise NotImplementedError
+    ---
+    class A:
+        def m(self, x):
+            raise NotImplementedError
+    """,
+    """
+    class A:
+        def m(self, x):
+            "some docstring"
+    ---
+    class A:
+        def m(self, x):
+            "some docstring"
+    """,
+    """
+    class A:
+        def m(self, x):
+            pass
+    ---
+    class A:
+        def m(self, x):
+            pass
+    """,
+    """
+    class A:
+        def m(self, x):
+            ...
+    ---
+    class A:
+        def m(self, x):
+            ...
+    """,
+    # infer no return for methods
+    """
+    class A:
+        def m(self, x):
+            pass
+            1 + 2
+    ---
+    class A:
+        def m(self, x) -> None:
+            pass
+            1 + 2
+    """,
+    """
+    class A:
+        def m(self, x):
+            13
+    ---
+    class A:
+        def m(self, x) -> None:
+            13
+    """,
 ])
 def test_inferno(transform, fused: str) -> None:
     given, expected = fused.split('---')


### PR DESCRIPTION
Do not annotate the return type as `None` for methods with the body like `pass`, `...`, `raise NotImplementedError` etc. Such methods can be abstract base class definitions.