### PR TITLE
Magic methods support, 1.0.0 release

### DIFF
--- a/infer_types/__init__.py
+++ b/infer_types/__init__.py
@@ -4,4 +4,4 @@ from ._cli import entrypoint, main
 
 
 __all__ = ['entrypoint', 'main']
-__version__ = '0.3.4'
+__version__ = '1.0.0'

--- a/infer_types/_constants.py
+++ b/infer_types/_constants.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from types import MappingProxyType
+
+from astypes import Type
+
+
+KNOWN_NAMES = MappingProxyType({
+    'dumps': 'str',
+    'exists': 'bool',
+    'contains': 'bool',
+    'count': 'int',
+    'size': 'int',
+})
+REMOVE_PREFIXES = ('as_', 'to_', 'get_')
+BOOL_PREFIXES = ('is_', 'has_', 'should_', 'can_', 'will_', 'supports_')
+
+t = Type.new
+tself = t('Self', module='typing')
+# https://docs.python.org/3/reference/datamodel.html
+MAGIC_METHODS = MappingProxyType(dict(
+    __contains__=t('bool'),
+    __del__=t('None'),
+    __delete__=t('None'),
+    __dir__=t('list', args=[t('str')]),
+    __exit__=t('Union', args=[t('bool'), t('None')]),
+    __format__=t('str'),
+    __hash__=t('int'),
+    __index__=t('int'),
+    __init__=t('None'),
+    __init_subclass__=t('None'),
+    __instancecheck__=t('bool'),
+    __iter__=t('Iterator', module='typing'),
+    __len__=t('int'),
+    __length_hint__=t('int'),
+    __new__=t('type'),
+    __nonzero__=t('bool'),
+    __repr__=t('str'),
+    __reversed__=t('Iterator', module='typing'),
+    __set__=t('None'),
+    __set_name__=t('None'),
+    __subclasscheck__=t('bool'),
+
+    # convert to types
+    __bool__=t('bool'),
+    __bytes__=t('bytes'),
+    __complex__=t('complex'),
+    __float__=t('float'),
+    __int__=t('int'),
+    __str__=t('str'),
+
+    # async/await
+    __aiter__=t('AsyncIterator', module='typing'),
+    __await__=t('Iterator', module='typing'),
+    __aexit__=t('Union', args=[t('bool'), t('None')]),
+
+    # comparison
+    __eq__=t('bool'),
+    __ne__=t('bool'),
+    __ge__=t('bool'),
+    __gt__=t('bool'),
+    __le__=t('bool'),
+    __lt__=t('bool'),
+
+    # arithmetic
+    __add__=tself,
+    __and__=tself,
+    __divmod__=tself,
+    __floordiv__=tself,
+    __lshift__=tself,
+    __matmul__=tself,
+    __mod__=tself,
+    __mul__=tself,
+    __or__=tself,
+    __pow__=tself,
+    __rshift__=tself,
+    __sub__=tself,
+    __truediv__=tself,
+    __xor__=tself,
+
+    # reversed arithmetic
+    __radd__=tself,
+    __rsub__=tself,
+    __rmul__=tself,
+    __rmatmul__=tself,
+    __rtruediv__=tself,
+    __rfloordiv__=tself,
+    __rmod__=tself,
+    __rdivmod__=tself,
+    __rpow__=tself,
+    __rlshift__=tself,
+    __rrshift__=tself,
+    __rand__=tself,
+    __rxor__=tself,
+    __ror__=tself,
+
+    # in-place arithmetic
+    __iadd__=tself,
+    __isub__=tself,
+    __imul__=tself,
+    __imatmul__=tself,
+    __itruediv__=tself,
+    __ifloordiv__=tself,
+    __imod__=tself,
+    __ipow__=tself,
+    __ilshift__=tself,
+    __irshift__=tself,
+    __iand__=tself,
+    __ixor__=tself,
+    __ior__=tself,
+
+    # unary operators
+    __neg__=tself,
+    __pos__=tself,
+    __abs__=tself,
+    __invert__=tself,
+
+    # number rounding operations
+    __round__=t('int'),
+    __trunc__=t('int'),
+    __floor__=t('int'),
+    __ceil__=t('int'),
+))

--- a/infer_types/_extractors.py
+++ b/infer_types/_extractors.py
@@ -135,6 +135,8 @@ def _extract_inherit_method(func_node: astroid.FunctionDef) -> Type:
 
 @register(name='magic')
 def _extract_magic_method(func_node: astroid.FunctionDef) -> Type:
+    if not func_node.is_method():
+        return UNKNOWN_TYPE
     return MAGIC_METHODS.get(func_node.name, UNKNOWN_TYPE)
 
 

--- a/infer_types/_extractors.py
+++ b/infer_types/_extractors.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import ast
 import builtins
 from collections import deque
-from types import MappingProxyType
 from typing import Callable, Iterator
 
 import astroid
@@ -11,21 +10,15 @@ import typeshed_client
 from astypes import Ass, Type, get_type
 from astypes._helpers import conv_node_to_type
 
+from ._constants import (
+    BOOL_PREFIXES, KNOWN_NAMES, MAGIC_METHODS, REMOVE_PREFIXES,
+)
+
 
 Extractor = Callable[[astroid.FunctionDef], Type]
 extractors: list[tuple[str, Extractor]] = []
 
 UNKNOWN_TYPE = Type.new('')
-
-KNOWN_NAMES = MappingProxyType({
-    'dumps': 'str',
-    'exists': 'bool',
-    'contains': 'bool',
-    'count': 'int',
-    'size': 'int',
-})
-REMOVE_PREFIXES = ('as_', 'to_', 'get_')
-BOOL_PREFIXES = ('is_', 'has_', 'should_', 'can_', 'will_', 'supports_')
 
 
 def register(name: str) -> Callable[[Extractor], Extractor]:
@@ -125,7 +118,8 @@ def _extract_inherit_method(func_node: astroid.FunctionDef) -> Type:
         if module is None:
             continue
         child_nodes = module[cls_name].child_nodes
-        assert child_nodes is not None
+        if child_nodes is None:
+            continue
         try:
             method_def = child_nodes[func_name]
         except KeyError:
@@ -137,6 +131,11 @@ def _extract_inherit_method(func_node: astroid.FunctionDef) -> Type:
         if return_type is not None:
             return return_type
     return UNKNOWN_TYPE
+
+
+@register(name='magic')
+def _extract_magic_method(func_node: astroid.FunctionDef) -> Type:
+    return MAGIC_METHODS.get(func_node.name, UNKNOWN_TYPE)
 
 
 @register(name='yield')

--- a/tests/test_inferno.py
+++ b/tests/test_inferno.py
@@ -316,6 +316,33 @@ def transform(tmp_path: Path) -> Callable:
             return
         yield x
     """,
+    # magic methods inference
+    """
+    class C:
+        def __int__(self):
+            ...
+    ---
+    class C:
+        def __int__(self) -> int:
+            ...
+    """,
+    """
+    class C:
+        def __iter__(self):
+            ...
+    ---
+    from typing import Iterator
+    class C:
+        def __iter__(self) -> Iterator:
+            ...
+    """,
+    """
+    def __int__(self):
+        return x
+    ---
+    def __int__(self):
+        return x
+    """,
 ])
 def test_inferno(transform, fused: str) -> None:
     given, expected = fused.split('---')


### PR DESCRIPTION
1. Automatically annotate return type of magic methods.
2. Set the version to 1.0.0. I'm happy enough how the tool performs on my 400k LoC project, so let's use a real semver.